### PR TITLE
chore: pin pull_request_target action to SHA

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,7 +11,7 @@ jobs:
   semantic-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: write
+
 jobs:
   semantic-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two hardening fixes for the \`pull_request_target\` workflow:

1. **Pin action to commit SHA** — replaces mutable tag \`@v6\` with a specific commit SHA, so the action code is immutable and cannot be silently redirected to a malicious commit.
2. **Add explicit \`permissions:\` block** — without it, \`GITHUB_TOKEN\` in a \`pull_request_target\` context has its default write scope across the entire repository. Restricting to \`pull-requests: write\` (the minimum the semantic-PR check needs) limits blast radius if a supply chain attack does occur.

## Why \`pull_request_target\` cannot be replaced here

\`pull_request\` events from forks always receive a read-only token regardless of \`permissions:\` settings — a hard GitHub platform limit. Write access to post the check result on fork PRs requires \`pull_request_target\`. The workflow is safe because **no code from the PR is checked out**.

## Changes

| File | Change |
|------|--------|
| \`.github/workflows/semantic-pr.yml\` | Pin \`amannn/action-semantic-pull-request\` to commit SHA |
| \`.github/workflows/semantic-pr.yml\` | Add \`permissions: pull-requests: write\` (minimal scope) |

## Test plan

- [ ] Open a test PR with a non-semantic title — workflow should fail as expected
- [ ] Open a test PR with a semantic title — workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)